### PR TITLE
Другой сериалайзер

### DIFF
--- a/components/RestSerializable.php
+++ b/components/RestSerializable.php
@@ -21,5 +21,5 @@ interface RestSerializable
      * Возвращает массив из текущей модели с учетом полей для реста и
      * @return array
      */
-    public function toRestArray();
+    public function toRestArray($configFields = [], $recursive = true);
 }

--- a/components/RestSerializable.php
+++ b/components/RestSerializable.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ravil
+ * Date: 22.04.17
+ * Time: 10:27
+ */
+
+namespace app\components;
+
+
+interface RestSerializable
+{
+    /**
+     * Возвращает дефолтный список полей для клиента, который может быть изменен содержанием переменной $restFields
+     * @return array
+     */
+    public function defaultRestFields();
+
+    /**
+     * Возвращает массив из текущей модели с учетом полей для реста и
+     * @return array
+     */
+    public function toRestArray();
+}

--- a/components/Serializer.php
+++ b/components/Serializer.php
@@ -46,9 +46,7 @@ class Serializer extends \yii\rest\Serializer
     public $configuratedFields = [];
 
     /**
-     * Serializes a model object.
-     * @param Arrayable $model
-     * @return array the array representation of the model
+     * @inheritdoc
      */
     protected function serializeModel($model)
     {
@@ -63,9 +61,27 @@ class Serializer extends \yii\rest\Serializer
     }
 
     /**
-     * Serializes a set of models.
-     * @param array $models
-     * @return array the array representation of the models
+     * @inheritdoc
+     */
+    protected function serializeModelErrors($model)
+    {
+        $this->response->setStatusCode(422, 'Data Validation Failed.');
+        $errors = [];
+        foreach ($model->getFirstErrors() as $name => $message) {
+            $errors[] = [
+                'field' => $name,
+                'message' => $message,
+            ];
+        }
+
+        $modelData = $this->serializeModel($model);
+        $modelData['errors'] = $errors;
+        return $modelData;
+    }
+
+    /**
+     * Обработка  так же и особых сериализуемых моделек
+     * @inheritdoc
      */
     protected function serializeModels(array $models)
     {

--- a/components/Serializer.php
+++ b/components/Serializer.php
@@ -9,6 +9,7 @@
 namespace app\components;
 
 
+use app\helpers\RestArrayHelper;
 use phpDocumentor\Reflection\DocBlock\Tags\Link;
 use yii\base\Arrayable;
 use yii\base\Model;
@@ -66,13 +67,7 @@ class Serializer extends \yii\rest\Serializer
     protected function serializeModelErrors($model)
     {
         $this->response->setStatusCode(422, 'Data Validation Failed.');
-        $errors = [];
-        foreach ($model->getFirstErrors() as $name => $message) {
-            $errors[] = [
-                'field' => $name,
-                'message' => $message,
-            ];
-        }
+        $errors =  RestArrayHelper::serializeModelErrors($model);
 
         $modelData = $this->serializeModel($model);
         $modelData['errors'] = $errors;

--- a/components/Serializer.php
+++ b/components/Serializer.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ravil
+ * Date: 17.04.17
+ * Time: 18:51
+ */
+
+namespace app\components;
+
+
+use phpDocumentor\Reflection\DocBlock\Tags\Link;
+use yii\base\Arrayable;
+use yii\base\Model;
+use yii\data\DataProviderInterface;
+use yii\data\Pagination;
+
+class Serializer extends \yii\rest\Serializer
+{
+    public $collectionEnvelope = 'data';
+
+    public $fieldsParam = 'only_fields';
+
+    /**
+     * Serializes a model object.
+     * @param Arrayable $model
+     * @return array the array representation of the model
+     */
+    protected function serializeModel($model)
+    {
+        if ($this->request->getIsHead()) {
+            return null;
+        } else {
+            list ($fields, $expand) = $this->getRequestedFields();
+            return $model->toArray($fields, $expand);
+        }
+    }
+
+    /**
+     * Serializes a set of models.
+     * @param array $models
+     * @return array the array representation of the models
+     */
+    protected function serializeModels(array $models)
+    {
+        list ($fields, $expand) = $this->getRequestedFields();
+        foreach ($models as $i => $model) {
+            if ($model instanceof Arrayable) {
+                $models[$i] = $model->toArray($fields, $expand);
+            } elseif (is_array($model)) {
+                $models[$i] = ArrayHelper::toArray($model);
+            }
+        }
+
+        return $models;
+    }
+
+}

--- a/components/Serializer.php
+++ b/components/Serializer.php
@@ -14,6 +14,7 @@ use yii\base\Arrayable;
 use yii\base\Model;
 use yii\data\DataProviderInterface;
 use yii\data\Pagination;
+use yii\helpers\ArrayHelper;
 
 class Serializer extends \yii\rest\Serializer
 {
@@ -43,9 +44,11 @@ class Serializer extends \yii\rest\Serializer
      */
     protected function serializeModels(array $models)
     {
-        list ($fields, $expand) = $this->getRequestedFields();
         foreach ($models as $i => $model) {
-            if ($model instanceof Arrayable) {
+            if ($model instanceof RestSerializable) {
+                $models[$i] = $model->toRestArray();
+            }elseif ($model instanceof Arrayable) {
+                list ($fields, $expand) = $this->getRequestedFields();
                 $models[$i] = $model->toArray($fields, $expand);
             } elseif (is_array($model)) {
                 $models[$i] = ArrayHelper::toArray($model);

--- a/components/ToRestArrayTrait.php
+++ b/components/ToRestArrayTrait.php
@@ -80,6 +80,7 @@ trait ToRestArrayTrait
 
         if ( !empty($this->configuratedRestFields ) ) {
             // либо конфигурация в модели
+            // todo принудительно добавить type
             $listOfFields = $this->configuratedRestFields;
         }elseif (
             !empty ($configFields)
@@ -87,9 +88,11 @@ trait ToRestArrayTrait
             && isset($configFields[$type])
         ){
             // либо в сериализаторе
+            // todo принудительно добавить type
             $listOfFields = $configFields[$type];
         }else{
             // или дефолтная конфигурация
+            // todo принудительно добавить type
             $listOfFields =  $this->defaultRestFields();
         }
         foreach ($listOfFields as $field => $definition) {

--- a/components/ToRestArrayTrait.php
+++ b/components/ToRestArrayTrait.php
@@ -62,6 +62,10 @@ trait ToRestArrayTrait
             $data['_links'] = Link::serialize($this->getLinks());
         }
 
+        if ($this->hasErrors()){
+            $data['errors'] = RestArrayHelper::serializeModelErrors($this);
+        }
+
         return $recursive ? RestArrayHelper::toArray($data, $configFields) : $data;
     }
 

--- a/components/ToRestArrayTrait.php
+++ b/components/ToRestArrayTrait.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ravil
+ * Date: 22.04.17
+ * Time: 11:30
+ */
+
+namespace app\components;
+
+
+use app\helpers\RestArrayHelper;
+use yii\helpers\ArrayHelper;
+use yii\web\Link;
+use yii\web\Linkable;
+
+trait ToRestArrayTrait
+{
+
+    /**
+     * Поля для рест-сериализатора, приоритетны перед дефолтными, могут содержать поля вложенных сущностей
+     * @var array
+     */
+    public $configuratedRestFields = [];
+
+    /**
+     * Дефолтный список для полей
+     * @return array
+     */
+    public function defaultRestFields()
+    {
+        return self::fields();
+    }
+
+    /**
+     * Преобразует модели для клиента по особым правилам без участия клинета
+     *
+     * @param bool $recursive whether to recursively return array representation of embedded objects.
+     * @return array the array representation of the object
+     */
+    public function toRestArray($recursive = true)
+    {
+        $data = [];
+        foreach ($this->resolveRestFields() as $field => $definition) {
+            $data[$field] = is_string($definition) ? $this->$definition : call_user_func($definition, $this, $field);
+        }
+
+        if ($this instanceof Linkable) {
+            $data['_links'] = Link::serialize($this->getLinks());
+        }
+
+        return $recursive ? RestArrayHelper::toArray($data) : $data;
+    }
+
+    /**
+     * Определяет какие поля должны быть представлены клиенту (конфигурирование)
+     * @return array the list of fields to be exported.
+     */
+    protected function resolveRestFields()
+    {
+        $result = [];
+
+        if ( empty($this->configuratedRestFields ) ) {
+            $listOfFields =  $this->defaultRestFields();
+        }else{
+            $listOfFields = $this->configuratedRestFields;
+        }
+        foreach ($listOfFields as $field => $definition) {
+            if (is_int($field)) {
+                $field = $definition;
+            }
+
+            $result[$field] = $definition;
+        }
+
+        return $result;
+    }
+}

--- a/components/behaviors/PushBehavior.php
+++ b/components/behaviors/PushBehavior.php
@@ -20,11 +20,15 @@ class PushBehavior extends Behavior
     {
         /** @var Response $responseObject */
         $responseObject = $event->sender;
-        \Yii::trace(\GuzzleHttp\json_encode($responseObject->statusCode));
+
         if ($responseObject->statusCode < 400){
-            $client = new Client();
-            $resp = $client->post(\Yii::$app->params['nodePushUrl'], ['body' => $responseObject->content]);
-            \Yii::trace($resp);
+            try {
+                $client = new Client();
+                $resp = $client->post(\Yii::$app->params['nodePushUrl'], ['body' => $responseObject->content]);
+                \Yii::trace($resp);
+            }catch (\Exception $ex){
+                \Yii::error($ex->getMessage());
+            }
         }
     }
 }

--- a/controllers/BaseActiveController.php
+++ b/controllers/BaseActiveController.php
@@ -13,6 +13,7 @@ use yii\rest\ActiveController;
 
 class BaseActiveController extends ActiveController
 {
+    public $serializer = 'app\components\Serializer';
 
     public function init()
     {

--- a/controllers/BaseActiveController.php
+++ b/controllers/BaseActiveController.php
@@ -15,6 +15,22 @@ class BaseActiveController extends ActiveController
 {
     public $serializer = 'app\components\Serializer';
 
+    /**
+     * Массив полей для проброса в сериализатор
+     * @var array
+     */
+    public $configuratedFields = [];
+
+    /**
+     * @inheritdoc
+     */
+    protected function serializeData($data)
+    {
+        $serializer = \Yii::createObject($this->serializer);
+        $serializer->configuratedFields = $this->configuratedFields;
+        return $serializer->serialize($data);
+    }
+
     public function init()
     {
         parent::init();

--- a/controllers/BaseRestController.php
+++ b/controllers/BaseRestController.php
@@ -16,15 +16,19 @@ class BaseRestController extends Controller
     public $serializer = 'app\components\Serializer';
 
     /**
-     * Serializes the specified data.
-     * The default implementation will create a serializer based on the configuration given by [[serializer]].
-     * It then uses the serializer to serialize the given data.
-     * @param mixed $data the data to be serialized
-     * @return mixed the serialized data.
+     * Массив полей для проброса в сериализатор
+     * @var array
+     */
+    public $configuratedFields = [];
+
+    /**
+     * @inheritdoc
      */
     protected function serializeData($data)
     {
-        return \Yii::createObject($this->serializer)->serialize($data);
+        $serializer = \Yii::createObject($this->serializer);
+        $serializer->configuratedFields = $this->configuratedFields;
+        return $serializer->serialize($data);
     }
 
     public function init()

--- a/controllers/BaseRestController.php
+++ b/controllers/BaseRestController.php
@@ -15,6 +15,18 @@ class BaseRestController extends Controller
 {
     public $serializer = 'app\components\Serializer';
 
+    /**
+     * Serializes the specified data.
+     * The default implementation will create a serializer based on the configuration given by [[serializer]].
+     * It then uses the serializer to serialize the given data.
+     * @param mixed $data the data to be serialized
+     * @return mixed the serialized data.
+     */
+    protected function serializeData($data)
+    {
+        return \Yii::createObject($this->serializer)->serialize($data);
+    }
+
     public function init()
     {
         parent::init();

--- a/controllers/BaseRestController.php
+++ b/controllers/BaseRestController.php
@@ -13,6 +13,8 @@ use yii\rest\Controller;
 
 class BaseRestController extends Controller
 {
+    public $serializer = 'app\components\Serializer';
+
     public function init()
     {
         parent::init();

--- a/controllers/ChatController.php
+++ b/controllers/ChatController.php
@@ -10,6 +10,9 @@ namespace app\controllers;
 
 
 
+use app\models\Chat;
+use yii\data\ActiveDataProvider;
+
 class ChatController extends BaseActiveController
 {
     public $modelClass = 'app\models\Chat';
@@ -20,4 +23,19 @@ class ChatController extends BaseActiveController
     }
 
     // todo дописать получние только своих чатов
+
+    public function afterAction($action, $result)
+    {
+        if ($action->id == 'index') {
+            /** @var ActiveDataProvider $result  */
+            if ($result instanceof Chat){
+                foreach ($result->models as $model){
+                    $model->configuratedRestFields = ['id'];
+                }
+            }
+        }
+        $resultSerylyzed = parent::afterAction($action, $result);
+        // your custom code here
+        return $resultSerylyzed;
+    }
 }

--- a/controllers/ChatController.php
+++ b/controllers/ChatController.php
@@ -9,10 +9,6 @@
 namespace app\controllers;
 
 
-
-use app\models\Chat;
-use yii\data\ActiveDataProvider;
-
 class ChatController extends BaseActiveController
 {
     public $modelClass = 'app\models\Chat';
@@ -20,22 +16,5 @@ class ChatController extends BaseActiveController
     public function actions() {
         $actions = parent::actions();
         return $actions;
-    }
-
-    // todo дописать получние только своих чатов
-
-    public function afterAction($action, $result)
-    {
-        if ($action->id == 'index') {
-            /** @var ActiveDataProvider $result  */
-            if ($result instanceof Chat){
-                foreach ($result->models as $model){
-                    $model->configuratedRestFields = ['id'];
-                }
-            }
-        }
-        $resultSerylyzed = parent::afterAction($action, $result);
-        // your custom code here
-        return $resultSerylyzed;
     }
 }

--- a/controllers/MessageController.php
+++ b/controllers/MessageController.php
@@ -24,8 +24,8 @@ class MessageController extends BaseActiveController
         if (parent::beforeAction($action)) {
             if ($action->id == 'create') {
                 $this->configuratedFields = [
-                    'message' => ['id', 'text', 'chat', 'date_create'],
-                    'chat' => ['id', 'users'],
+                    'message' => ['id', 'text', 'chat', 'date_create', 'type'],
+                    'chat' => ['id', 'users', 'type', 'userIds'],
                     'user' => ['id', 'displayname', 'type']
                 ];
 

--- a/controllers/MessageController.php
+++ b/controllers/MessageController.php
@@ -23,6 +23,12 @@ class MessageController extends BaseActiveController
     public function beforeAction($action){
         if (parent::beforeAction($action)) {
             if ($action->id == 'create') {
+                $this->configuratedFields = [
+                    'message' => ['id', 'text', 'chat', 'date_create'],
+                    'chat' => ['id', 'users'],
+                    'user' => ['id', 'displayname', 'type']
+                ];
+
                 $component = \Yii::$app->response;
                 $component->attachBehavior('PushBehavior', [
                     'class' => PushBehavior::className(),

--- a/controllers/MessageController.php
+++ b/controllers/MessageController.php
@@ -20,10 +20,18 @@ class MessageController extends BaseActiveController
         return $actions;
     }
 
-    public function init(){
-        $component = \Yii::$app->response;
-        $component->attachBehavior('PushBehavior', [
-            'class' => PushBehavior::className(),
-        ]);
+    public function beforeAction($action){
+        if (parent::beforeAction($action)) {
+            if ($action->id == 'create') {
+                $component = \Yii::$app->response;
+                $component->attachBehavior('PushBehavior', [
+                    'class' => PushBehavior::className(),
+                ]);
+            }
+
+            return true;
+        }
+
+        return false;
     }
 }

--- a/helpers/RestArrayHelper.php
+++ b/helpers/RestArrayHelper.php
@@ -16,39 +16,10 @@ use yii\helpers\BaseArrayHelper;
 class RestArrayHelper extends BaseArrayHelper
 {
     /**
-     * Converts an object or an array of objects into an array.
-     * @param object|array|string $object the object to be converted into an array
-     * @param array $properties a mapping from object class names to the properties that need to put into the resulting arrays.
-     * The properties specified for each class is an array of the following format:
+     * Преобразует модели в массивы с учетом RestSerializable интерфейса
      *
-     * ```php
-     * [
-     *     'app\models\Post' => [
-     *         'id',
-     *         'title',
-     *         // the key name in array result => property name
-     *         'createTime' => 'created_at',
-     *         // the key name in array result => anonymous function
-     *         'length' => function ($post) {
-     *             return strlen($post->content);
-     *         },
-     *     ],
-     * ]
-     * ```
-     *
-     * The result of `ArrayHelper::toArray($post, $properties)` could be like the following:
-     *
-     * ```php
-     * [
-     *     'id' => 123,
-     *     'title' => 'test',
-     *     'createTime' => '2013-01-01 12:00AM',
-     *     'length' => 301,
-     * ]
-     * ```
-     *
-     * @param bool $recursive whether to recursively converts properties which are objects into arrays.
-     * @return array the array representation of the object
+     * @inheritdoc
+     * @param array $properties массив конфигов полей для каждого типа моделек
      */
     public static function toArray($object, $properties = [], $recursive = true)
     {

--- a/helpers/RestArrayHelper.php
+++ b/helpers/RestArrayHelper.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ravil
+ * Date: 22.04.17
+ * Time: 13:24
+ */
+
+namespace app\helpers;
+
+
+use app\components\RestSerializable;
+use yii\base\Arrayable;
+use yii\helpers\BaseArrayHelper;
+
+class RestArrayHelper extends BaseArrayHelper
+{
+    /**
+     * Converts an object or an array of objects into an array.
+     * @param object|array|string $object the object to be converted into an array
+     * @param array $properties a mapping from object class names to the properties that need to put into the resulting arrays.
+     * The properties specified for each class is an array of the following format:
+     *
+     * ```php
+     * [
+     *     'app\models\Post' => [
+     *         'id',
+     *         'title',
+     *         // the key name in array result => property name
+     *         'createTime' => 'created_at',
+     *         // the key name in array result => anonymous function
+     *         'length' => function ($post) {
+     *             return strlen($post->content);
+     *         },
+     *     ],
+     * ]
+     * ```
+     *
+     * The result of `ArrayHelper::toArray($post, $properties)` could be like the following:
+     *
+     * ```php
+     * [
+     *     'id' => 123,
+     *     'title' => 'test',
+     *     'createTime' => '2013-01-01 12:00AM',
+     *     'length' => 301,
+     * ]
+     * ```
+     *
+     * @param bool $recursive whether to recursively converts properties which are objects into arrays.
+     * @return array the array representation of the object
+     */
+    public static function toArray($object, $properties = [], $recursive = true)
+    {
+        // todo сделать отбрасывание верхнего уровня конфига
+        // и проброс нижележашей части в дальнейшем рекурсивном использовании в массивах и нижележащих моделей
+        if (is_array($object)) {
+            if ($recursive) {
+                foreach ($object as $key => $value) {
+                    if (is_array($value) || is_object($value)) {
+                        $object[$key] = static::toArray($value, $properties, true);
+                    }
+                }
+            }
+
+            return $object;
+        } elseif (is_object($object)) {
+            if (!empty($properties)) {
+                $className = get_class($object);
+                if (!empty($properties[$className])) {
+                    $result = [];
+                    foreach ($properties[$className] as $key => $name) {
+                        if (is_int($key)) {
+                            $result[$name] = $object->$name;
+                        } else {
+                            $result[$key] = static::getValue($object, $name);
+                        }
+                    }
+
+                    return $recursive ? static::toArray($result, $properties) : $result;
+                }
+            }
+            if ($object instanceof RestSerializable) {
+                $result = $object->toRestArray();
+            }elseif ($object instanceof Arrayable) {
+                // todo если поля определены то отдать только эти поля
+                $result = $object->toArray([], [], $recursive);
+            } else {
+                $result = [];
+                foreach ($object as $key => $value) {
+                    // todo  если поля определены то отдать только эти поля
+                    $result[$key] = $value;
+                }
+            }
+
+            return $recursive ? static::toArray($result, $properties) : $result;
+        } else {
+            return [$object];
+        }
+    }
+
+}

--- a/helpers/RestArrayHelper.php
+++ b/helpers/RestArrayHelper.php
@@ -97,4 +97,16 @@ class RestArrayHelper extends BaseArrayHelper
         }
     }
 
+    public static function serializeModelErrors ($model) {
+        $errors = [];
+        foreach ($model->getFirstErrors() as $name => $message) {
+            $errors[] = [
+                'field' => $name,
+                'message' => $message,
+            ];
+        }
+
+        return $errors;
+    }
+
 }

--- a/helpers/RestArrayHelper.php
+++ b/helpers/RestArrayHelper.php
@@ -52,8 +52,6 @@ class RestArrayHelper extends BaseArrayHelper
      */
     public static function toArray($object, $properties = [], $recursive = true)
     {
-        // todo сделать отбрасывание верхнего уровня конфига
-        // и проброс нижележашей части в дальнейшем рекурсивном использовании в массивах и нижележащих моделей
         if (is_array($object)) {
             if ($recursive) {
                 foreach ($object as $key => $value) {
@@ -81,7 +79,7 @@ class RestArrayHelper extends BaseArrayHelper
                 }
             }
             if ($object instanceof RestSerializable) {
-                $result = $object->toRestArray();
+                $result = $object->toRestArray($properties);
             }elseif ($object instanceof Arrayable) {
                 // todo если поля определены то отдать только эти поля
                 $result = $object->toArray([], [], $recursive);

--- a/models/BaseModel.php
+++ b/models/BaseModel.php
@@ -9,10 +9,13 @@
 namespace app\models;
 
 
+use app\components\RestSerializable;
+use app\components\ToRestArrayTrait;
 use yii\db\ActiveRecord;
 
-class BaseModel extends ActiveRecord
+class BaseModel extends ActiveRecord implements RestSerializable
 {
+    use ToRestArrayTrait;
     /**
      * @inheritdoc
      */

--- a/models/Chat.php
+++ b/models/Chat.php
@@ -17,6 +17,7 @@ use yii\base\Exception;
  * @property User[] $Users
  * @property Message[] $lastMessages
  * @property array $usersIds
+ * @property  User $creatorUser
  */
 class Chat extends BaseModel
 {
@@ -98,6 +99,14 @@ class Chat extends BaseModel
             ->viaTable('chat_to_user', ['chat_id' => 'id'])
             ->select('user.id')
             ->column();
+    }
+
+    /**
+     * @return \yii\db\ActiveQuery
+     */
+    public function getCreatorUser()
+    {
+        return $this->hasOne(User::className(), ['id' => 'creator']);
     }
 
     /**

--- a/models/Chat.php
+++ b/models/Chat.php
@@ -60,6 +60,13 @@ class Chat extends BaseModel
         return $fields;
     }
 
+    public function defaultRestFields()
+    {
+        $restFields = parent::defaultRestFields();
+        $restFields[] = 'users';
+        return $restFields;
+    }
+
     /**
      * @inheritdoc
      */

--- a/models/User.php
+++ b/models/User.php
@@ -22,7 +22,7 @@ use Yii;
  * @property boolean $inactive
  * @property boolean $veryfied
  */
-class User extends \yii\db\ActiveRecord
+class User extends BaseModel
 {
     /**
      * @inheritdoc
@@ -49,9 +49,9 @@ class User extends \yii\db\ActiveRecord
         ];
     }
 
-    public function restFields() {
+    public function defaultRestFields() {
 
-        $restFields = self::fields();
+        $restFields = parent::defaultRestFields();
         unset($restFields['auth_key']);
         unset($restFields['objectsid']);
         unset($restFields['password']);
@@ -88,6 +88,11 @@ class User extends \yii\db\ActiveRecord
             $this->auth_key = \Yii::$app->security->generateRandomString();
         }
         return parent::beforeValidate();
+    }
+
+    public function getChats () {
+        return $this->hasMany(Chat::className(), ['id' => 'chat_id'])
+            ->viaTable('chat_to_user', ['user_id' => 'id']);
     }
 
 }

--- a/models/User.php
+++ b/models/User.php
@@ -49,6 +49,16 @@ class User extends \yii\db\ActiveRecord
         ];
     }
 
+    public function restFields() {
+
+        $restFields = self::fields();
+        unset($restFields['auth_key']);
+        unset($restFields['objectsid']);
+        unset($restFields['password']);
+        unset($restFields['objectguid']);
+        return $restFields;
+    }
+
     /**
      * @inheritdoc
      */

--- a/node/server.js
+++ b/node/server.js
@@ -24,7 +24,7 @@ http.createServer(function (req, res) {
                     // здесь надо переделать способ передаци айдишников на более универсальный
                     // todo сделать try - catch и логи
                     bodyParsed = JSON.parse(body);
-                    clientIds = bodyParsed.chat.userIds;
+                    clientIds = bodyParsed.data.chat.userIds;
                     chat.publish(body, clientIds);
                     res.end('ok');
                 });


### PR DESCRIPTION
Стандартный сериалайзер не выполняет свою функцию вьюхи в РЕСТ приложении:
- экспанд и филдс определяются фронтом, что мне кажется опасным (например я не могу добавить секретное поле в expand для одномго запроса (к примеру access_token) потому что иначе его запросит кто угодно с фронта)
- они влияют только на первый уровень выдачи - либо самой модельки либо списка
- метаинформация передается только в заголовках (по умолчанию)
- нет гибкости в переопределении значении полей, которые присутствуют в базе (например хочу я существующее в базе поле заполнить для конкретного запроса другими данными)
- нет возможности в одном поле выдавать разную информацию (например мне хочется чтобы в поле lastMessages при запросе чата приходили 3 последние сообщения, а в другом запросе мне нужно вставить туда сообщения за последний день, например)

**Решение: нужно, чтобы при отправке моделек (в тч подобных вложенных) клинету они сериализовались для клиента не обычным образом а с учетом следующих требований:**

- чтобы данные в бд АР не портили гибкость выдачи модели - надо чтобы можно было получать с клиента поля совпадающие с названием колонки таблицы с произвольным содержанием
- чтобы ошибки всегда присоединялись к данным модели а не замещали их, в тч и внутри списка и внутри других моделей (если для них производилась валидация - Не сделано -)
- чтобы на уровне модели, контроллера (не клиента) я мог конфигурировать список полей, например в сообщении при его создании отдать чат не весь а только айдишник и название,
- причем конфигурировать нужно все нижележащие модели в тч лежащие внутри массивов.

