### PR TITLE
вместо списка полей можно 

### DIFF
--- a/components/Serializer.php
+++ b/components/Serializer.php
@@ -146,7 +146,7 @@ class Serializer extends \yii\rest\Serializer
 
         if (($pagination = $dataProvider->getPagination()) !== false) {
             $this->addPaginationHeaders($pagination);
-            $this->paginationData = $this->serializePagination($pagination);
+            $this->linkAndPaginationData = $this->serializePagination($pagination);
         }
 
         return $models;

--- a/controllers/ChatController.php
+++ b/controllers/ChatController.php
@@ -17,4 +17,20 @@ class ChatController extends BaseActiveController
         $actions = parent::actions();
         return $actions;
     }
+
+    public function beforeAction($action){
+        if (parent::beforeAction($action)) {
+            if ($action->id == 'index') {
+                $this->configuratedFields = [
+                    'chat' => ['id', 'type', 'users'],
+                    'user:app\views\RestUser' => ['id', 'displayname', 'type']
+                ];
+
+            }
+
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/views/RestUser.php
+++ b/views/RestUser.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ravil
+ * Date: 21.05.17
+ * Time: 18:44
+ */
+
+namespace app\views;
+
+
+use app\models\User;
+use yii\base\Exception;
+
+class RestUser extends ViewModel
+{
+
+    public function init(){
+        if (!( $this->model instanceof User)) {
+            throw new Exception('Данная вьюха работает только с юзерами');
+        }
+    }
+
+    public function toRestArray($fields = [])
+    {
+        /** @var User $user */
+        $user = $this->model;
+        if (!\Yii::$app->user->isGuest){
+            $data = [];
+            foreach ($fields as $field => $definition) {
+                $data[$field] = is_string($definition) ? $user->$definition : call_user_func($definition, $user, $field);
+            }
+        }else{
+            $data = ['id' => $user->id, 'cn' => $user->cn];
+        }
+
+        return $data;
+    }
+}

--- a/views/ViewModel.php
+++ b/views/ViewModel.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: ravil
+ * Date: 21.05.17
+ * Time: 18:37
+ */
+
+namespace app\views;
+
+
+use yii\base\Model;
+
+abstract class ViewModel extends Model
+{
+    public $model = null;
+
+    abstract public function toRestArray($configFields = []);
+}


### PR DESCRIPTION
Проблема - иногда вместо изменения списка полей нужно поменять всю логику отображения модели (например отображая список пользователей друзей показывать более подробно или например друзьям показывать весь телефон, а остальным пользователям только первые и последние цифры

Решение - в конфигурацию отправлять не только тип модели но и модель вьюхи, отвечающую за отображение и соответственно использующую сомпоненты запроса, ответа и пользьователя